### PR TITLE
Update genepi-io to 1.2.0

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -139,7 +139,7 @@
 		<dependency>
 			<groupId>genepi</groupId>
 			<artifactId>genepi-io</artifactId>
-			<version>1.0.12</version>
+			<version>1.2.0</version>
 		</dependency>
 
 		<dependency>


### PR DESCRIPTION
We need to update genepi-io to 1.2.0, because haplogrep3 uses the CSVTableReader for annotation and only 1.2.0 supports gzip.